### PR TITLE
Only check ipv6 addresses against ipv6 subnets and v4 against v4

### DIFF
--- a/src/ipAllowed.js
+++ b/src/ipAllowed.js
@@ -11,22 +11,45 @@ module.exports = function(allowedSubnets) {
   assert(allowedSubnets, 'Must provide allowed subnets in CIDR format');
   assert(Array.isArray(allowedSubnets), 'Allowed subnets must be a list');
 
-  let subnets = [];
+  let subnetsV4 = [];
+  let subnetsV6 = [];
 
   for (let subnet of allowedSubnets) {
-    subnets.push(ipaddr.parseCIDR(subnet));
+    let parsed = ipaddr.parseCIDR(subnet);
+    // Let's be sure that this value is a 2-tuple of an object and a mask
+    // length.  Probably overkill
+    assert(typeof parsed[0] === 'object');
+    assert(typeof parsed[1] === 'number');
+    assert(parsed.length === 2);
+    if (parsed[0].kind() === 'ipv4') {
+      subnetsV4.push(parsed);
+    } else if (parsed[0].kind() === 'ipv6') {
+      subnetsV6.push(parsed);
+    } else {
+      assert(false, 'CIDR Specifies unknown address type');
+    }
   }
 
   return function(ip) {
     // Parse the IP into an IP object
     ip = ipaddr.parse(ip);
 
-    // Go through the subnets and see if we can match any.  A match means the
-    // ip is in the subnet
-    for (let subnet of subnets) {
-      if (ip.match(subnet)) {
-        return true;
+    // We want to match IPv4 addresses to allowed IPv4 subnets and IPv6 to
+    // allowed IPv6 subnets
+    if (ip.kind() === 'ipv4') {
+      for (let subnet of subnetsV4) {
+        if (ip.match(subnet)) {
+          return true;
+        }
       }
+    } else if (ip.kind() === 'ipv6') {
+      for (let subnet of subnetsV6) {
+        if (ip.match(subnet)) {
+          return true;
+        }
+      }
+    } else {
+      throw new Error('Ip address is unexpected format: ' + ip.kind());
     }
 
     // If we didn't find our IP in an allowed subnet, we need to return false

--- a/test/ipAllowed_test.js
+++ b/test/ipAllowed_test.js
@@ -24,6 +24,25 @@ suite('ipAllowed', function() {
     assert(!allowed('2001:0:0:0:0:ffff:100:1'));
   });
 
+  test('only validate ipv6 addresses in ipv6 subnets', function() {
+    let allowed = ipAllowed(['2001:0:0:0:0:ffff:100:0/128']);
+    assert(!allowed('1.0.0.1'));
+  });
+
+  test('only validate ipv4 addresses in ipv4 subnets', function() {
+    let allowed = ipAllowed(['1.0.0.1/32']);
+    assert(!allowed('2001:0:0:0:0:ffff:100:1'));
+  });
+
+  test('ipv4 and v6 both validate when subnets of both types are provided', function() {
+    let allowed = ipAllowed([
+      '0.0.0.0/0',
+      '::/0',
+    ]);
+    assert(allowed('1.0.0.0'));
+    assert(allowed('::45:1'));
+  });
+
   test('allowed from multiple subnets', function() {
     let allowed = ipAllowed([
       '1.0.0.0/32',

--- a/user-config-example.yml
+++ b/user-config-example.yml
@@ -1,7 +1,18 @@
 defaults:
-  # Example file showing how to write a user-config.yml file that contains
-  # credentials for running tests locally. Notice that user-config.yml is
-  # ignored in .gitignore
-  pulse:
-    username: '...'
-    password: '...'
+  taskcluster:
+    scopeBase: '...'
+    clientIdBase: '...'
+    credentialsExpire: '...'
+    allowedIps:
+      - "0.0.0.0/0"
+      - "0:0:0:0:0:0:0:0/0"
+    credentials:
+      clientId: '...'
+      accessToken: '...'
+
+  server:
+    publicUrl: '...'
+    port: 443
+    env: production
+    forceSSL: true
+    trustProxy: false


### PR DESCRIPTION
So I discovered at the office, where we have IPv6 unlike my home, that real IPv6 addresses don't validate against IPv4 subnets, even though it was working in the unit tests.  I've changed the code to figure out whether a given subnet is a V6 or V4 subnet.  Then, incoming addresses are compared only to subnets which are of the same type as the incoming address.

If this looks good to you, feel free to merge.

Also an example user-config.yml file for deployment.