### PR TITLE
Include node-gyp, since it's necessary to build usage

### DIFF
--- a/host-secrets.spec.in
+++ b/host-secrets.spec.in
@@ -37,6 +37,7 @@ mv node-%{nodever}-%{nodearch} node
 export PATH="$(pwd)/node/bin:$PATH"
 node --version
 npm --version
+npm install -g node-gyp
 sed -e "s,<<<BINDIR>>>,/%{INST}/node/bin," < code/init.d.in > init.d.sh
 sed -e "s,<<<BINDIR>>>,/%{INST}/node/bin," < code/start.sh.in > bin/start.sh
 (cd code && npm install)


### PR DESCRIPTION
I needed this to build 1.0.2 in [bug 1341654](https://bugzilla.mozilla.org/show_bug.cgi?id=1341654)