### PR TITLE
explicit path to logger

### DIFF
--- a/start.sh.in
+++ b/start.sh.in
@@ -101,5 +101,5 @@ export TRUST_PROXY=$trustproxy
 export FORCE_SSL=$forcessl
 
 cd $bindir/../../code/
-exec 1> >(logger -s -t tc-host-secrets) 2>&1
+exec 1> >(/bin/logger -s -t tc-host-secrets) 2>&1
 exec node lib/main server


### PR DESCRIPTION
for some reason it's not found on centos without this